### PR TITLE
change: remove aggregated node types as it may enduce conflicts

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,8 +7,15 @@ export default tseslint.config(
   nodePlugin.configs['flat/recommended'],
   ...tseslint.configs.recommended,
   {
+    languageOptions: {
+      parserOptions: {
+        project: './tsconfig.meta.json',
+      },
+    },
     rules: {
       'no-console': 'error',
+      '@typescript-eslint/no-use-before-define': 'error',
+      '@typescript-eslint/no-duplicate-type-constituents': 'error',
       '@typescript-eslint/no-unused-vars': [
         'error',
         {
@@ -49,5 +56,8 @@ export default tseslint.config(
         },
       ],
     },
+  },
+  {
+    ignores: ['dist', 'coverage', 'eslint.config.js'],
   },
 )

--- a/src/baseVisitor.ts
+++ b/src/baseVisitor.ts
@@ -96,9 +96,6 @@ export class BaseVisitor<T> implements Required<RecursiveVisitors<T>> {
   ClassExpression<S>(_n: swc.ClassExpression, _st: S, _cb: Callback<S>) {
     // not implemented
   }
-  ClassMember<S>(_n: swc.ClassMember, _st: S, _cb: Callback<S>) {
-    // not implemented
-  }
   ClassMethod<S>(_n: swc.ClassMethod, _st: S, _cb: Callback<S>) {
     // not implemented
   }
@@ -120,13 +117,7 @@ export class BaseVisitor<T> implements Required<RecursiveVisitors<T>> {
   DebuggerStatement<S>(_n: swc.DebuggerStatement, _st: S, _cb: Callback<S>) {
     // not implemented
   }
-  Declaration<S>(_n: swc.Declaration, _st: S, _cb: Callback<S>) {
-    // not implemented
-  }
   Decorator<S>(_n: swc.Decorator, _st: S, _cb: Callback<S>) {
-    // not implemented
-  }
-  DefaultDecl<S>(_n: swc.DefaultDecl, _st: S, _cb: Callback<S>) {
     // not implemented
   }
   DoWhileStatement<S>(_n: swc.DoWhileStatement, _st: S, _cb: Callback<S>) {
@@ -156,10 +147,7 @@ export class BaseVisitor<T> implements Required<RecursiveVisitors<T>> {
   ExportNamespaceSpecifier<S>(_n: swc.ExportNamespaceSpecifier, _st: S, _cb: Callback<S>) {
     // not implemented
   }
-  ExportSpecifier<S>(_n: swc.ExportSpecifier, _st: S, _cb: Callback<S>) {
-    // not implemented
-  }
-  Expression<S>(_n: swc.Expression, _st: S, _cb: Callback<S>) {
+  ExportSpecifier<S>(_n: swc.NamedExportSpecifier, _st: S, _cb: Callback<S>) {
     // not implemented
   }
   ExpressionStatement<S>(n: swc.ExpressionStatement, st: S, cb: Callback<S>) {
@@ -199,16 +187,13 @@ export class BaseVisitor<T> implements Required<RecursiveVisitors<T>> {
   ImportNamespaceSpecifier<S>(_n: swc.ImportNamespaceSpecifier, _st: S, _cb: Callback<S>) {
     // not implemented
   }
-  ImportSpecifier<S>(_n: swc.ImportSpecifier, _st: S, _cb: Callback<S>) {
+  ImportSpecifier<S>(_n: swc.NamedImportSpecifier, _st: S, _cb: Callback<S>) {
     // not implemented
   }
   Invalid<S>(_n: swc.Invalid, _st: S, _cb: Callback<S>) {
     // not implemented
   }
   JSXAttribute<S>(_n: swc.JSXAttribute, _st: S, _cb: Callback<S>) {
-    // not implemented
-  }
-  JSXAttrValue<S>(_n: swc.JSXAttrValue, _st: S, _cb: Callback<S>) {
     // not implemented
   }
   JSXClosingElement<S>(_n: swc.JSXClosingElement, _st: S, _cb: Callback<S>) {
@@ -218,12 +203,6 @@ export class BaseVisitor<T> implements Required<RecursiveVisitors<T>> {
     // not implemented
   }
   JSXElement<S>(_n: swc.JSXElement, _st: S, _cb: Callback<S>) {
-    // not implemented
-  }
-  JSXElementChild<S>(_n: swc.JSXElementChild, _st: S, _cb: Callback<S>) {
-    // not implemented
-  }
-  JSXElementName<S>(_n: swc.JSXElementName, _st: S, _cb: Callback<S>) {
     // not implemented
   }
   JSXEmptyExpression<S>(_n: swc.JSXEmptyExpression, _st: S, _cb: Callback<S>) {
@@ -262,9 +241,6 @@ export class BaseVisitor<T> implements Required<RecursiveVisitors<T>> {
   LabeledStatement<S>(_n: swc.LabeledStatement, _st: S, _cb: Callback<S>) {
     // not implemented
   }
-  Literal<S>(_n: swc.Literal, _st: S, _cb: Callback<S>) {
-    // not implemented
-  }
   MemberExpression<S>(n: swc.MemberExpression, st: S, cb: Callback<S>) {
     cb(n.object, st)
     cb(n.property, st)
@@ -279,9 +255,6 @@ export class BaseVisitor<T> implements Required<RecursiveVisitors<T>> {
     for (const stmt of n.body) {
       cb(stmt, st)
     }
-  }
-  ModuleDeclaration<S>(_n: swc.ModuleDeclaration, _st: S, _cb: Callback<S>) {
-    // not implemented
   }
   NewExpression<S>(n: swc.NewExpression, st: S, cb: Callback<S>) {
     cb(n.callee, st)
@@ -306,9 +279,6 @@ export class BaseVisitor<T> implements Required<RecursiveVisitors<T>> {
   ObjectPattern<S>(_n: swc.ObjectPattern, _st: S, _cb: Callback<S>) {
     // not implemented
   }
-  ObjectPatternProperty<S>(_n: swc.ObjectPatternProperty, _st: S, _cb: Callback<S>) {
-    // not implemented
-  }
   OptionalChainingExpression<S>(_n: swc.OptionalChainingExpression, _st: S, _cb: Callback<S>) {
     // not implemented
   }
@@ -318,9 +288,6 @@ export class BaseVisitor<T> implements Required<RecursiveVisitors<T>> {
   ParenthesisExpression<S>(_n: swc.ParenthesisExpression, _st: S, _cb: Callback<S>) {
     // not implemented
   }
-  Pattern<S>(_n: swc.Pattern, _st: S, _cb: Callback<S>) {
-    // not implemented
-  }
   PrivateMethod<S>(_n: swc.PrivateMethod, _st: S, _cb: Callback<S>) {
     // not implemented
   }
@@ -328,12 +295,6 @@ export class BaseVisitor<T> implements Required<RecursiveVisitors<T>> {
     // not implemented
   }
   PrivateProperty<S>(_n: swc.PrivateProperty, _st: S, _cb: Callback<S>) {
-    // not implemented
-  }
-  Property<S>(_n: swc.Property, _st: S, _cb: Callback<S>) {
-    // not implemented
-  }
-  PropertyName<S>(_n: swc.PropertyName, _st: S, _cb: Callback<S>) {
     // not implemented
   }
   RegExpLiteral<S>(_n: swc.RegExpLiteral, _st: S, _cb: Callback<S>) {
@@ -359,9 +320,6 @@ export class BaseVisitor<T> implements Required<RecursiveVisitors<T>> {
     // not implemented
   }
   SpreadElement<S>(_n: swc.SpreadElement, _st: S, _cb: Callback<S>) {
-    // not implemented
-  }
-  Statement<S>(_n: swc.Statement, _st: S, _cb: Callback<S>) {
     // not implemented
   }
   StaticBlock<S>(_n: swc.StaticBlock, _st: S, _cb: Callback<S>) {
@@ -479,9 +437,6 @@ export class BaseVisitor<T> implements Required<RecursiveVisitors<T>> {
   TsExternalModuleReference<S>(_n: swc.TsExternalModuleReference, _st: S, _cb: Callback<S>) {
     // not implemented
   }
-  TsFnParameter<S>(_n: swc.TsFnParameter, _st: S, _cb: Callback<S>) {
-    // not implemented
-  }
   TsFunctionType<S>(_n: swc.TsFunctionType, _st: S, _cb: Callback<S>) {
     // not implemented
   }
@@ -539,9 +494,6 @@ export class BaseVisitor<T> implements Required<RecursiveVisitors<T>> {
   TsParameterProperty<S>(_n: swc.TsParameterProperty, _st: S, _cb: Callback<S>) {
     // not implemented
   }
-  TsParameterPropertyParameter<S>(_n: swc.TsParameterPropertyParameter, _st: S, _cb: Callback<S>) {
-    // not implemented
-  }
   TsParenthesizedType<S>(_n: swc.TsParenthesizedType, _st: S, _cb: Callback<S>) {
     // not implemented
   }
@@ -577,9 +529,6 @@ export class BaseVisitor<T> implements Required<RecursiveVisitors<T>> {
       cb(n.typeParams, st)
     }
   }
-  TsType<S>(_n: swc.TsType, _st: S, _cb: Callback<S>) {
-    // not implemented
-  }
   TsTypeAnnotation<S>(n: swc.TsTypeAnnotation, st: S, cb: Callback<S>) {
     cb(n.typeAnnotation, st)
   }
@@ -600,9 +549,6 @@ export class BaseVisitor<T> implements Required<RecursiveVisitors<T>> {
     }
   }
   TsTypeAssertion<S>(_n: swc.TsTypeAssertion, _st: S, _cb: Callback<S>) {
-    // not implemented
-  }
-  TsTypeElement<S>(_n: swc.TsTypeElement, _st: S, _cb: Callback<S>) {
     // not implemented
   }
   TsTypeLiteral<S>(_n: swc.TsTypeLiteral, _st: S, _cb: Callback<S>) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import * as swc from '@swc/types'
+import type * as swc from '@swc/types'
 
 export interface Node extends swc.Node {
   /**
@@ -15,204 +15,71 @@ export interface Node extends swc.Node {
    */
   span?: swc.Span
 }
-export type AggregateType = {
-  ClassMember: swc.ClassMember
-  Declaration: swc.Declaration
-  DefaultDecl: swc.DefaultDecl
-  ExportSpecifier: swc.ExportSpecifier
-  Expression: swc.Expression
-  ImportSpecifier: swc.ImportSpecifier
-  JSXAttrValue: swc.JSXAttrValue
-  JSXElementChild: swc.JSXElementChild
-  JSXElementName: swc.JSXElementName
-  Literal: swc.Literal
-  ModuleDeclaration: swc.ModuleDeclaration
-  ObjectPatternProperty: swc.ObjectPatternProperty
-  Pattern: swc.Pattern
-  Property: swc.Property
-  PropertyName: swc.PropertyName
-  Statement: swc.Statement
-  TsFnParameter: swc.TsFnParameter
-  TsParameterPropertyParameter: swc.TsParameterPropertyParameter
-  TsType: swc.TsType
-  TsTypeElement: swc.TsTypeElement
-}
-export type AnyNode =
-  | swc.ArrayExpression
-  | swc.ArrayPattern
-  | swc.ArrowFunctionExpression
-  | swc.AssignmentExpression
-  | swc.AssignmentPattern
-  | swc.AssignmentPatternProperty
-  | swc.AssignmentProperty
-  | swc.AwaitExpression
-  | swc.BigIntLiteral
-  | swc.BinaryExpression
-  | swc.BlockStatement
-  | swc.BooleanLiteral
-  | swc.BreakStatement
-  | swc.CallExpression
-  | swc.CallExpression
-  | swc.CatchClause
-  | swc.ClassDeclaration
-  | swc.ClassExpression
-  | swc.ClassMethod
-  | swc.ClassProperty
-  | swc.ComputedPropName
-  | swc.ConditionalExpression
-  | swc.Constructor
-  | swc.ContinueStatement
-  | swc.DebuggerStatement
-  | swc.Decorator
-  | swc.DoWhileStatement
-  | swc.EmptyStatement
-  | swc.ExportAllDeclaration
-  | swc.ExportDeclaration
-  | swc.ExportDefaultDeclaration
-  | swc.ExportDefaultExpression
-  | swc.ExportDefaultSpecifier
-  | swc.ExportNamedDeclaration
-  | swc.ExportNamespaceSpecifier
+
+type AggregatedNode =
+  | swc.ClassMember
+  | swc.Declaration
+  | swc.DefaultDecl
   | swc.ExportSpecifier
-  | swc.ExpressionStatement
-  | swc.ForInStatement
-  | swc.ForOfStatement
-  | swc.ForStatement
-  | swc.FunctionDeclaration
-  | swc.FunctionExpression
-  | swc.GetterProperty
-  | swc.Identifier
-  | swc.Identifier
-  | swc.IfStatement
-  | swc.Import
-  | swc.ImportDeclaration
-  | swc.ImportDefaultSpecifier
-  | swc.ImportNamespaceSpecifier
+  | swc.Expression
   | swc.ImportSpecifier
-  | swc.Invalid
+  | swc.JSXAttrValue
+  | swc.JSXElementChild
+  | swc.JSXElementName
+  | swc.Literal
+  | swc.ModuleDeclaration
+  | swc.ObjectPatternProperty
+  | swc.Pattern
+  | swc.Property
+  | swc.PropertyName
+  | swc.Statement
+  | swc.TsFnParameter
+  | swc.TsParameterPropertyParameter
+  | swc.TsType
+  | swc.TsTypeElement
+
+export type AnyNode =
+  | AggregatedNode
+  | swc.CatchClause
+  | swc.Decorator
+  | swc.Import
   | swc.JSXAttribute
   | swc.JSXClosingElement
   | swc.JSXClosingFragment
-  | swc.JSXElement
-  | swc.JSXEmptyExpression
-  | swc.JSXExpressionContainer
-  | swc.JSXFragment
-  | swc.JSXMemberExpression
-  | swc.JSXNamespacedName
   | swc.JSXOpeningElement
   | swc.JSXOpeningFragment
-  | swc.JSXSpreadChild
-  | swc.JSXText
-  | swc.KeyValuePatternProperty
-  | swc.KeyValueProperty
-  | swc.LabeledStatement
-  | swc.MemberExpression
-  | swc.MetaProperty
-  | swc.MethodProperty
   | swc.Module
-  | swc.NewExpression
-  | swc.NullLiteral
-  | swc.NumericLiteral
-  | swc.ObjectExpression
-  | swc.ObjectPattern
-  | swc.OptionalChainingExpression
   | swc.Param
-  | swc.ParenthesisExpression
-  | swc.PrivateMethod
-  | swc.PrivateName
-  | swc.PrivateProperty
-  | swc.RegExpLiteral
-  | swc.RestElement
-  | swc.ReturnStatement
   | swc.Script
-  | swc.SequenceExpression
-  | swc.SetterProperty
   | swc.SpreadElement
-  | swc.StaticBlock
-  | swc.StringLiteral
   | swc.Super
-  | swc.SuperPropExpression
   | swc.SwitchCase
-  | swc.SwitchStatement
-  | swc.TaggedTemplateExpression
   | swc.TemplateElement
-  | swc.TemplateLiteral
-  | swc.TemplateLiteral
-  | swc.ThisExpression
-  | swc.ThrowStatement
-  | swc.TryStatement
-  | swc.TsArrayType
-  | swc.TsAsExpression
-  | swc.TsCallSignatureDeclaration
-  | swc.TsConditionalType
-  | swc.TsConstAssertion
-  | swc.TsConstructSignatureDeclaration
   | swc.TsConstructorType
-  | swc.TsEnumDeclaration
   | swc.TsEnumMember
-  | swc.TsExportAssignment
   | swc.TsExpressionWithTypeArguments
   | swc.TsExternalModuleReference
   | swc.TsFunctionType
-  | swc.TsGetterSignature
-  | swc.TsImportEqualsDeclaration
-  | swc.TsImportType
-  | swc.TsIndexSignature
-  | swc.TsIndexedAccessType
-  | swc.TsInferType
-  | swc.TsInstantiation
   | swc.TsInterfaceBody
-  | swc.TsInterfaceDeclaration
   | swc.TsIntersectionType
-  | swc.TsKeywordType
-  | swc.TsLiteralType
-  | swc.TsMappedType
-  | swc.TsMethodSignature
   | swc.TsModuleBlock
-  | swc.TsModuleDeclaration
   | swc.TsNamespaceDeclaration
-  | swc.TsNamespaceExportDeclaration
-  | swc.TsNonNullExpression
-  | swc.TsOptionalType
   | swc.TsParameterProperty
-  | swc.TsParenthesizedType
-  | swc.TsPropertySignature
   | swc.TsQualifiedName
-  | swc.TsRestType
-  | swc.TsSatisfiesExpression
-  | swc.TsSetterSignature
-  | swc.TsThisType
   | swc.TsTupleElement
-  | swc.TsTupleType
-  | swc.TsTypeAliasDeclaration
   | swc.TsTypeAnnotation
-  | swc.TsTypeAssertion
-  | swc.TsTypeLiteral
-  | swc.TsTypeOperator
   | swc.TsTypeParameter
   | swc.TsTypeParameterDeclaration
   | swc.TsTypeParameterInstantiation
-  | swc.TsTypePredicate
-  | swc.TsTypeQuery
-  | swc.TsTypeReference
   | swc.TsUnionType
-  | swc.UnaryExpression
-  | swc.UpdateExpression
-  | swc.VariableDeclaration
   | swc.VariableDeclarator
-  | swc.WhileStatement
-  | swc.WithStatement
-  | swc.YieldExpression
+
 export type Callback<State> = (node: Node, state: State) => void
 export type RecursiveVisitors<State> = {
   [type in AnyNode['type']]?: (node: Extract<AnyNode, { type: type }>, state: State, callback: Callback<State>) => void
-} & {
-  [type in keyof AggregateType]?: (node: AggregateType[type], state: State, callback: Callback<State>) => void
 }
 export type SimpleVisitors<State> = {
   [type in AnyNode['type']]?: (node: Extract<AnyNode, { type: type }>, state: State) => void
-} & {
-  [type in keyof AggregateType]?: (node: AggregateType[type], state: State) => void
 }
 /**
  * does a 'simple' walk over a tree

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,30 +16,31 @@ export interface Node extends swc.Node {
   span?: swc.Span
 }
 
-type AggregatedNode =
-  | swc.ClassMember
-  | swc.Declaration
-  | swc.DefaultDecl
-  | swc.ExportSpecifier
-  | swc.Expression
-  | swc.ImportSpecifier
-  | swc.JSXAttrValue
-  | swc.JSXElementChild
-  | swc.JSXElementName
-  | swc.Literal
-  | swc.ModuleDeclaration
-  | swc.ObjectPatternProperty
-  | swc.Pattern
-  | swc.Property
-  | swc.PropertyName
-  | swc.Statement
-  | swc.TsFnParameter
-  | swc.TsParameterPropertyParameter
-  | swc.TsType
-  | swc.TsTypeElement
+type AggregatedNode = {
+  ClassMember: swc.ClassMember
+  Declaration: swc.Declaration
+  DefaultDecl: swc.DefaultDecl
+  ExportSpecifier: swc.ExportSpecifier
+  Expression: swc.Expression
+  ImportSpecifier: swc.ImportSpecifier
+  JSXAttrValue: swc.JSXAttrValue
+  JSXElementChild: swc.JSXElementChild
+  JSXElementName: swc.JSXElementName
+  Literal: swc.Literal
+  ModuleDeclaration: swc.ModuleDeclaration
+  ObjectPatternProperty: swc.ObjectPatternProperty
+  Pattern: swc.Pattern
+  Property: swc.Property
+  PropertyName: swc.PropertyName
+  Statement: swc.Statement
+  TsFnParameter: swc.TsFnParameter
+  TsParameterPropertyParameter: swc.TsParameterPropertyParameter
+  TsType: swc.TsType
+  TsTypeElement: swc.TsTypeElement
+}
 
 export type AnyNode =
-  | AggregatedNode
+  | AggregatedNode[keyof AggregatedNode]
   | swc.CatchClause
   | swc.Decorator
   | swc.Import
@@ -80,6 +81,8 @@ export type RecursiveVisitors<State> = {
 }
 export type SimpleVisitors<State> = {
   [type in AnyNode['type']]?: (node: Extract<AnyNode, { type: type }>, state: State) => void
+} & {
+  [type in keyof AggregatedNode as `Aggregated${type}`]?: never //(node: AggregatedNode[type], state: State) => void
 }
 /**
  * does a 'simple' walk over a tree

--- a/src/walk.ts
+++ b/src/walk.ts
@@ -1,3 +1,4 @@
+import type { Node } from '@swc/types'
 import { simple as acornSimpleWalk } from 'acorn-walk'
 
 import { BaseVisitor } from './baseVisitor.js'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,6 @@
     "outDir": "dist",
     "target": "ESNext"
   },
+  "references": [{ "path": "./tsconfig.meta.json" }],
   "include": ["src"]
 }

--- a/tsconfig.meta.json
+++ b/tsconfig.meta.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "composite": true
+  },
+  "extends": "./tsconfig.json",
+  "include": ["src", "test", "eslint.config.js"]
+}


### PR DESCRIPTION
### what does it do ?

- remove AggregatedType
- remove hanlders for AggregatedType

### why is it useful ?

AggregatedType led to think that we can listen on nodes like `Property` while it is not the case, no node will have a type `Property` but it will be `Identifier`, `KeyValueProperty`, ...

A second reason is that aggregated types `swc.ImportSpecifier` and `swc.ExportSpecifier` could lead to conflict with `swc.NamedImportSpecifier` and `swc.NamedExportSpecifier` whose **type** property is set to `ImportSpecifier` and `ExportSpecifier` respectively.
