### PR TITLE
fix: visitor overlapping types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swc-walk",
-  "version": "1.0.0-rc.0",
+  "version": "1.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "swc-walk",
-      "version": "1.0.0-rc.0",
+      "version": "1.0.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "acorn-walk": "^8.3.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swc-walk",
-  "version": "1.0.0-rc.0",
+  "version": "1.0.0-rc.1",
   "description": "Walk an AST from SWC and visit each node type.",
   "main": "dist/esm/walk.js",
   "type": "module",

--- a/src/baseVisitor.ts
+++ b/src/baseVisitor.ts
@@ -4,7 +4,7 @@ import type { Node, Callback, RecursiveVisitors } from './types.js'
 
 const ignore = <S>(_n: Node, _st: S, _cb: Callback<S>) => {}
 
-export class BaseVisitor<T> implements Required<RecursiveVisitors<T>> {
+export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
   ArrayExpression<S>(n: swc.ArrayExpression, st: S, cb: Callback<S>) {
     for (const el of n.elements) {
       if (el) {
@@ -348,9 +348,8 @@ export class BaseVisitor<T> implements Required<RecursiveVisitors<T>> {
       cb(n.body, st)
     }
   }
-  Identifier(n: swc.Identifier, st: T, cb: Callback<T>) {
+  Identifier<S>(n: swc.Identifier | swc.BindingIdentifier, st: S, cb: Callback<S>) {
     if ('typeAnnotation' in n && n.typeAnnotation) {
-      // @ts-expect-error -- typeAnnotation is not typed in Identifier
       cb(n.typeAnnotation, st)
     }
   }
@@ -647,13 +646,15 @@ export class BaseVisitor<T> implements Required<RecursiveVisitors<T>> {
     }
   }
   TemplateElement = ignore
-  TemplateLiteral<S>(n: swc.TemplateLiteral, st: S, cb: Callback<S>) {
+  TemplateLiteral<S>(n: swc.TemplateLiteral | swc.TsTemplateLiteralType, st: S, cb: Callback<S>) {
     for (const quasis of n.quasis) {
       cb(quasis, st)
     }
 
-    for (const expressions of n.expressions) {
-      cb(expressions, st)
+    if ('expressions' in n) {
+      for (const expressions of n.expressions) {
+        cb(expressions, st)
+      }
     }
   }
   ThisExpression = ignore

--- a/src/baseVisitor.ts
+++ b/src/baseVisitor.ts
@@ -656,6 +656,12 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
         cb(expressions, st)
       }
     }
+
+    if ('types' in n) {
+      for (const types of n.types) {
+        cb(types, st)
+      }
+    }
   }
   ThisExpression = ignore
   ThrowStatement<S>(n: swc.ThrowStatement, st: S, cb: Callback<S>) {

--- a/src/walk.ts
+++ b/src/walk.ts
@@ -7,7 +7,7 @@ import type { SimpleVisitors } from './types.js'
 export function simple<T = unknown>(
   ast: Node,
   visitors: SimpleVisitors<T>,
-  baseVisitor = new BaseVisitor<T>(),
+  baseVisitor = new BaseVisitor(),
   state?: T,
 ) {
   // @ts-expect-error (acorn-walk ast nodes have start/end instead of span)

--- a/test/baseVisitors.test.ts
+++ b/test/baseVisitors.test.ts
@@ -121,6 +121,7 @@ const tests: Array<Test> = [
   { type: 'TaggedTemplateExpression', code: 'foo<T>`bar ${baz}`' },
   { type: 'TemplateElement', code: 'foo`bar`' },
   { type: 'TemplateLiteral', code: 'foo`bar`' },
+  { type: 'TemplateLiteral', code: 'type foo = `${bar}`' },
   { type: 'ThisExpression', code: 'this' },
   { type: 'ThrowStatement', code: 'throw 1' },
   { type: 'TryStatement', code: 'try {} catch(e) {}' },

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -7,7 +7,7 @@ import { simple } from '../src/walk.js'
 import { BaseVisitor } from '../src/baseVisitor.js'
 
 export type Test = {
-  type: keyof BaseVisitor<unknown>
+  type: keyof BaseVisitor
   skip?: string
   code: string
   times?: number


### PR DESCRIPTION
**PR Description**

This PR includes the following changes:

- In `src/baseVisitor.ts`:
    - Updated the `BaseVisitor` class to use `unknown` as the type parameter for `RecursiveVisitors`.
    - Modified the `Identifier` method to accept both `swc.Identifier` and `swc.BindingIdentifier` types.
    - Updated the `TemplateLiteral` method to handle both `swc.TemplateLiteral` and `swc.TsTemplateLiteralType` types.

- In `test/baseVisitors.test.ts`:
    - Added a new test case for `TemplateLiteral` type with a template string containing a variable.

