### PR TITLE
feat: expose helpers, align spans, and modernize config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,7 +2,7 @@ import eslint from '@eslint/js'
 import tseslint from 'typescript-eslint'
 import nodePlugin from 'eslint-plugin-n'
 
-export default tseslint.config(
+export default [
   eslint.configs.recommended,
   nodePlugin.configs['flat/recommended'],
   ...tseslint.configs.strictTypeChecked,
@@ -67,7 +67,7 @@ export default tseslint.config(
     files: ['test/*'],
     languageOptions: {
       parserOptions: {
-        project: './test/tsconfig.json',
+        project: './tsconfig.eslint.json',
       },
     },
     rules: {
@@ -86,4 +86,4 @@ export default tseslint.config(
   {
     ignores: ['dist', 'coverage', 'eslint.config.js'],
   },
-)
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
-        "@knighted/duel": "^2.1.5",
+        "@knighted/duel": "^2.1.6",
         "@knighted/dump": "^1.0.3",
         "@stylistic/eslint-plugin-js": "^2.1.0",
         "@swc/core": "^1.15.2",
@@ -47,14 +47,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
-      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
+      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.3",
-        "@babel/types": "^7.28.2",
+        "@babel/parser": "^7.28.5",
+        "@babel/types": "^7.28.5",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -84,9 +84,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -94,13 +94,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
-      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.2"
+        "@babel/types": "^7.28.5"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -125,18 +125,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz",
-      "integrity": "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
+      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.3",
+        "@babel/generator": "^7.28.5",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.3",
+        "@babel/parser": "^7.28.5",
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.2",
+        "@babel/types": "^7.28.5",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -144,14 +144,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -168,9 +168,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
-      "integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.7.1.tgz",
+      "integrity": "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -180,9 +180,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
-      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
+      "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1014,18 +1014,18 @@
       }
     },
     "node_modules/@knighted/duel": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@knighted/duel/-/duel-2.1.5.tgz",
-      "integrity": "sha512-3F5NDPHkxWOslO7SbMWOF9D8BgIvxkhhe8z3UP+p5oS5hfqf2tl9CZip7oGdde7JMZKmwT4Zkp5HCzuh/4dIzg==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@knighted/duel/-/duel-2.1.6.tgz",
+      "integrity": "sha512-zNpBcVn08x7f6m/esgaT0ys+msnTw+pk1pHBGwL6pL1TmGZ70IhnSOJ447JqBHSeVb1XL1p6PkB5PvBWxCrQqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@knighted/module": "^1.0.0-alpha.9",
-        "@knighted/specifier": "^2.0.7",
-        "find-up": "^7.0.0",
-        "get-tsconfig": "^4.10.1",
-        "glob": "^11.0.3",
-        "read-package-up": "^11.0.0"
+        "@knighted/module": "^1.0.0-alpha.10",
+        "@knighted/specifier": "^2.0.9",
+        "find-up": "^8.0.0",
+        "get-tsconfig": "^4.13.0",
+        "glob": "^13.0.0",
+        "read-package-up": "^12.0.0"
       },
       "bin": {
         "duel": "dist/esm/duel.js"
@@ -1034,59 +1034,42 @@
         "node": ">=20.11.0"
       },
       "peerDependencies": {
-        "typescript": ">=5.5.0-dev || >=5.6.0-dev || >=5.7.0-dev || next"
+        "typescript": ">=5.5.0 <6",
+        "typescript-next": "npm:typescript@next"
+      },
+      "peerDependenciesMeta": {
+        "typescript-next": {
+          "optional": true
+        }
       }
     },
     "node_modules/@knighted/duel/node_modules/find-up": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-7.0.0.tgz",
-      "integrity": "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-8.0.0.tgz",
+      "integrity": "sha512-JGG8pvDi2C+JxidYdIwQDyS/CgcrIdh18cvgxcBge3wSHRQOrooMD3GlFBcmMJAN9M42SAZjDp5zv1dglJjwww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "locate-path": "^7.2.0",
-        "path-exists": "^5.0.0",
-        "unicorn-magic": "^0.1.0"
+        "locate-path": "^8.0.0",
+        "unicorn-magic": "^0.3.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@knighted/duel/node_modules/glob": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
-      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.0.3",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@knighted/duel/node_modules/jackspeak": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "path-scurry": "^2.0.0"
       },
       "engines": {
         "node": "20 || >=22"
@@ -1096,25 +1079,25 @@
       }
     },
     "node_modules/@knighted/duel/node_modules/locate-path": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
-      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-8.0.0.tgz",
+      "integrity": "sha512-XT9ewWAC43tiAV7xDAPflMkG0qOPn2QjHqlgX8FOqmWa/rxnyYDulF9T0F7tRy1u+TVTmK/M//6VIOye+2zDXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^6.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@knighted/duel/node_modules/lru-cache": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
-      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -1122,11 +1105,11 @@
       }
     },
     "node_modules/@knighted/duel/node_modules/minimatch": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
-      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/brace-expansion": "^5.0.0"
       },
@@ -1169,20 +1152,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@knighted/duel/node_modules/path-exists": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
     "node_modules/@knighted/duel/node_modules/path-scurry": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
-      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -1197,9 +1170,9 @@
       }
     },
     "node_modules/@knighted/duel/node_modules/yocto-queue": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
-      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1219,9 +1192,9 @@
       }
     },
     "node_modules/@knighted/module": {
-      "version": "1.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@knighted/module/-/module-1.0.0-alpha.9.tgz",
-      "integrity": "sha512-PYA/Ql8c4G3q13Fsuah3oCP3pQE906RwD72/aKzCT2oboDiAKEUpPaDuwEnc5pStvISqRxYcg0NXceRvL4dZJw==",
+      "version": "1.0.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@knighted/module/-/module-1.0.0-alpha.10.tgz",
+      "integrity": "sha512-dIAFlP2hX3h4ucoynkj/m73hqsgC3KLpGvDhMOuRKn7GcjBFHO0Ot2w6pb/nhCIWzMYI+1KQLk1TK42nDwdKhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1238,24 +1211,322 @@
       }
     },
     "node_modules/@knighted/specifier": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@knighted/specifier/-/specifier-2.0.7.tgz",
-      "integrity": "sha512-M/cBnS9lgaxG8rjQ+oSaEqzGIhBoeIk1MiJldESbnEW/+ExdeMdTty2+X759Zg02FNgeHHfGXdangUwqJWvvMA==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@knighted/specifier/-/specifier-2.0.9.tgz",
+      "integrity": "sha512-r+g/NVHDKSUu4gQh72x6A8l3Qh3X3L0qpF9hd+SYrawfmzyaTyXH02n8lpl1PpaGwnmcJOU2q95sI0m/Ifppxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@knighted/walk": "^1.0.0",
-        "magic-string": "^0.30.17",
-        "oxc-parser": "^0.78.0"
+        "@knighted/walk": "^1.0.1",
+        "magic-string": "^0.30.21",
+        "oxc-parser": "^0.99.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
+    "node_modules/@knighted/specifier/node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.99.0.tgz",
+      "integrity": "sha512-V4jhmKXgQQdRnm73F+r3ZY4pUEsijQeSraFeaCGng7abSNJGs76X6l82wHnmjLGFAeY00LWtjcELs7ZmbJ9+lA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@knighted/specifier/node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.99.0.tgz",
+      "integrity": "sha512-Rp41nf9zD5FyLZciS9l1GfK8PhYqrD5kEGxyTOA2esTLeAy37rZxetG2E3xteEolAkeb2WDkVrlxPtibeAncMg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@knighted/specifier/node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.99.0.tgz",
+      "integrity": "sha512-WVonp40fPPxo5Gs0POTI57iEFv485TvNKOHMwZRhigwZRhZY2accEAkYIhei9eswF4HN5B44Wybkz7Gd1Qr/5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@knighted/specifier/node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.99.0.tgz",
+      "integrity": "sha512-H30bjOOttPmG54gAqu6+HzbLEzuNOYO2jZYrIq4At+NtLJwvNhXz28Hf5iEAFZIH/4hMpLkM4VN7uc+5UlNW3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@knighted/specifier/node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.99.0.tgz",
+      "integrity": "sha512-0Z/Th0SYqzSRDPs6tk5lQdW0i73UCupnim3dgq2oW0//UdLonV/5wIZCArfKGC7w9y4h8TxgXpgtIyD1kKzzlQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@knighted/specifier/node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.99.0.tgz",
+      "integrity": "sha512-xo0wqNd5bpbzQVNpAIFbHk1xa+SaS/FGBABCd942SRTnrpxl6GeDj/s1BFaGcTl8MlwlKVMwOcyKrw/2Kdfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@knighted/specifier/node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.99.0.tgz",
+      "integrity": "sha512-u26I6LKoLTPTd4Fcpr0aoAtjnGf5/ulMllo+QUiBhupgbVCAlaj4RyXH/mvcjcsl2bVBv9E/gYJZz2JjxQWXBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@knighted/specifier/node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.99.0.tgz",
+      "integrity": "sha512-qhftDo2D37SqCEl3ZTa367NqWSZNb1Ddp34CTmShLKFrnKdNiUn55RdokLnHtf1AL5ssaQlYDwBECX7XiBWOhw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@knighted/specifier/node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.99.0.tgz",
+      "integrity": "sha512-zxn/xkf519f12FKkpL5XwJipsylfSSnm36h6c1zBDTz4fbIDMGyIhHfWfwM7uUmHo9Aqw1pLxFpY39Etv398+Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@knighted/specifier/node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.99.0.tgz",
+      "integrity": "sha512-Y1eSDKDS5E4IVC7Oxw+NbYAKRmJPMJTIjW+9xOWwteDHkFqpocKe0USxog+Q1uhzalD9M0p9eXWEWdGQCMDBMQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@knighted/specifier/node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.99.0.tgz",
+      "integrity": "sha512-YVJMfk5cFWB8i2/nIrbk6n15bFkMHqWnMIWkVx7r2KwpTxHyFMfu2IpeVKo1ITDSmt5nBrGdLHD36QRlu2nDLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@knighted/specifier/node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.99.0.tgz",
+      "integrity": "sha512-2+SDPrie5f90A1b9EirtVggOgsqtsYU5raZwkDYKyS1uvJzjqHCDhG/f4TwQxHmIc5YkczdQfwvN91lwmjsKYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@knighted/specifier/node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.99.0.tgz",
+      "integrity": "sha512-DKA4j0QerUWSMADziLM5sAyM7V53Fj95CV9SjP77bPfEfT7MnvFKnneaRMqPK1cpzjAGiQF52OBUIKyk0dwOQA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.0.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@knighted/specifier/node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.99.0.tgz",
+      "integrity": "sha512-EaB3AvsxqdNUhh9FOoAxRZ2L4PCRwDlDb//QXItwyOJrX7XS+uGK9B1KEUV4FZ/7rDhHsWieLt5e07wl2Ti5AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@knighted/specifier/node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.99.0.tgz",
+      "integrity": "sha512-sJN1Q8h7ggFOyDn0zsHaXbP/MklAVUvhrbq0LA46Qum686P3SZQHjbATqJn9yaVEvaSKXCshgl0vQ1gWkGgpcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@knighted/specifier/node_modules/@oxc-project/types": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.99.0.tgz",
+      "integrity": "sha512-LLDEhXB7g1m5J+woRSgfKsFPS3LhR9xRhTeIoEBm5WrkwMxn6eZ0Ld0c0K5eHB57ChZX6I3uSmmLjZ8pcjlRcw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@knighted/specifier/node_modules/oxc-parser": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.99.0.tgz",
+      "integrity": "sha512-MpS1lbd2vR0NZn1v0drpgu7RUFu3x9Rd0kxExObZc2+F+DIrV0BOMval/RO3BYGwssIOerII6iS8EbbpCCZQpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.99.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm64": "0.99.0",
+        "@oxc-parser/binding-darwin-arm64": "0.99.0",
+        "@oxc-parser/binding-darwin-x64": "0.99.0",
+        "@oxc-parser/binding-freebsd-x64": "0.99.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.99.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.99.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.99.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.99.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.99.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.99.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.99.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.99.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.99.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.99.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.99.0"
+      }
+    },
     "node_modules/@knighted/walk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@knighted/walk/-/walk-1.0.0.tgz",
-      "integrity": "sha512-cBM9+XDBicWArHfD1rTFOo+2UYCE/wlla1BGwktGvKiq/2I7eSf7FdmM1MmbQCTameIP8rJaz0nDi1uLgBMqxw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@knighted/walk/-/walk-1.0.1.tgz",
+      "integrity": "sha512-A/JHCHRK3e0gjqZcjoonZrdfQbMTrRg94ul5C0paYfsglPtJ9HdGm8iqZlgR0syzVBBaRdHc5HjgMhglZXta2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1269,16 +1540,16 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.3.tgz",
-      "integrity": "sha512-rZxtMsLwjdXkMUGC3WwsPwLNVqVqnTJT6MNIB6e+5fhMcSCPP0AOsNWuMQ5mdCq6HNjs/ZeWAEchpqeprqBD2Q==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.7.tgz",
+      "integrity": "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.4.5",
-        "@emnapi/runtime": "^1.4.5",
-        "@tybys/wasm-util": "^0.10.0"
+        "@emnapi/core": "^1.5.0",
+        "@emnapi/runtime": "^1.5.0",
+        "@tybys/wasm-util": "^0.10.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1839,9 +2110,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
-      "integrity": "sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1892,7 +2163,8 @@
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.46.4",
@@ -2825,10 +3097,11 @@
       }
     },
     "node_modules/find-up-simple": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.0.tgz",
-      "integrity": "sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -2886,15 +3159,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -2905,9 +3169,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
-      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
+      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3018,28 +3282,27 @@
         "node": ">=8"
       }
     },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+    "node_modules/hosted-git-info": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+      "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "function-bind": "^1.1.2"
+        "lru-cache": "^11.1.0"
       },
       "engines": {
-        "node": ">= 0.4"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/hosted-git-info": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^10.0.1"
-      },
+      "license": "ISC",
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "20 || >=22"
       }
     },
     "node_modules/html-escaper": {
@@ -3085,27 +3348,16 @@
       }
     },
     "node_modules/index-to-position": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-0.1.2.tgz",
-      "integrity": "sha512-MWDKS3AS1bGCHLBA2VLImJz42f7bJh8wQsTGCzI3j519/CASStoDONUBVz2I/VID0MpiX3SGSnbOD2xUalbE5g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-core-module": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
-      "dev": true,
-      "dependencies": {
-        "hasown": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -3313,9 +3565,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.18",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
-      "integrity": "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3396,32 +3648,33 @@
       "dev": true
     },
     "node_modules/node-module-type": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/node-module-type/-/node-module-type-1.0.2.tgz",
-      "integrity": "sha512-5UZUtgz2txICZxHjwODRUzU316wFl8F9P1nU8ri7KwFW3FNCHVtXEeRed2CBdKyiijrNNl2hpoUSKtjXASn29w==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/node-module-type/-/node-module-type-1.0.4.tgz",
+      "integrity": "sha512-jJEWdpQFDFhjA87debF8AgaBXPkHyFCw/6atsRwOGu/bpVwje1ZAl8/0WuwxrYNRUdWQ5YNUOT0ARSZeqjFlGA==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
+        "test/ambiguous",
         "test/cjslib",
         "test/esmlib"
       ],
       "engines": {
-        "node": ">=20.11.0"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/normalize-package-data": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.1.tgz",
-      "integrity": "sha512-6rvCfeRW+OEZagAB4lMLSNuTNYZWLVtKccK79VSTf//yTY5VOCgcpH80O+bZK8Neps7pUnd5G+QlMg1yV/2iZQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
+      "integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "hosted-git-info": "^7.0.0",
-        "is-core-module": "^2.8.1",
+        "hosted-git-info": "^9.0.0",
         "semver": "^7.3.5",
         "validate-npm-package-license": "^3.0.4"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/optionator": {
@@ -3505,13 +3758,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3526,17 +3772,31 @@
       }
     },
     "node_modules/parse-json": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.1.0.tgz",
-      "integrity": "sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "index-to-position": "^0.1.2",
-        "type-fest": "^4.7.1"
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-json/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3653,36 +3913,38 @@
       "license": "MIT"
     },
     "node_modules/read-package-up": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
-      "integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-12.0.0.tgz",
+      "integrity": "sha512-Q5hMVBYur/eQNWDdbF4/Wqqr9Bjvtrw2kjGxxBbKLbx8bVCL8gcArjTy8zDUuLGQicftpMuU0riQNcAsbtOVsw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "find-up-simple": "^1.0.0",
-        "read-pkg": "^9.0.0",
-        "type-fest": "^4.6.0"
+        "find-up-simple": "^1.0.1",
+        "read-pkg": "^10.0.0",
+        "type-fest": "^5.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/read-pkg": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
-      "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.0.0.tgz",
+      "integrity": "sha512-A70UlgfNdKI5NSvTTfHzLQj7NJRpJ4mT5tGafkllJ4wh71oYuGm/pzphHcmW4s35iox56KSK721AihodoXSc/A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/normalize-package-data": "^2.4.3",
-        "normalize-package-data": "^6.0.0",
-        "parse-json": "^8.0.0",
-        "type-fest": "^4.6.0",
-        "unicorn-magic": "^0.1.0"
+        "@types/normalize-package-data": "^2.4.4",
+        "normalize-package-data": "^8.0.0",
+        "parse-json": "^8.3.0",
+        "type-fest": "^5.2.0",
+        "unicorn-magic": "^0.3.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3802,6 +4064,7 @@
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
       "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -3811,23 +4074,26 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
       "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
-      "dev": true
+      "dev": true,
+      "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.18",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.18.tgz",
-      "integrity": "sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ==",
-      "dev": true
+      "version": "3.0.22",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
+      "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -3906,6 +4172,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tapable": {
@@ -4063,12 +4342,16 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.18.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.3.tgz",
-      "integrity": "sha512-Q08/0IrpvM+NMY9PA2rti9Jb+JejTddwmwmVQGskAlhtcrw1wsRzoR6ode6mR+OAabNa75w/dxedSUY2mlphaQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.2.0.tgz",
+      "integrity": "sha512-xxCJm+Bckc6kQBknN7i9fnP/xobQRsRQxR01CztFkp/h++yfVxUUcmMgfR2HttJx/dpWjS9ubVuyspJv24Q9DA==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4121,10 +4404,11 @@
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
-      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -4161,6 +4445,7 @@
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,23 @@
       },
       "default": "./dist/esm/baseVisitor.js"
     },
+    "./types": {
+      "import": {
+        "types": "./dist/esm/types.d.ts",
+        "default": "./dist/esm/types.js"
+      },
+      "require": {
+        "types": "./dist/cjs/types.d.cts",
+        "default": "./dist/cjs/types.cjs"
+      },
+      "default": "./dist/esm/types.js"
+    },
     "./package.json": "./package.json"
+  },
+  "imports": {
+    "#swc-walk": "./src/walk.ts",
+    "#swc-walk/baseVisitor": "./src/baseVisitor.ts",
+    "#swc-walk/types": "./src/types.ts"
   },
   "engines": {
     "node": ">=20.2.0"
@@ -64,7 +80,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
-    "@knighted/duel": "^2.1.5",
+    "@knighted/duel": "^2.1.6",
     "@knighted/dump": "^1.0.3",
     "@stylistic/eslint-plugin-js": "^2.1.0",
     "@swc/core": "^1.15.2",

--- a/src/baseVisitor.ts
+++ b/src/baseVisitor.ts
@@ -1,6 +1,4 @@
-import type * as swc from '@swc/types'
-
-import type { Node, Callback, RecursiveVisitors } from './types.js'
+import type { Node, Callback, NodeByType, RecursiveVisitors } from './types.js'
 
 const ignore = <S>(_n: Node, _st: S, _cb: Callback<S>) => {}
 
@@ -8,32 +6,40 @@ const ignore = <S>(_n: Node, _st: S, _cb: Callback<S>) => {}
  * @see https://github.com/swc-project/swc/blob/main/packages/core/src/Visitor.ts
  */
 export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
-  ArrayExpression<S>(n: swc.ArrayExpression, st: S, cb: Callback<S>) {
+  ArrayExpression<S>(n: NodeByType<'ArrayExpression'>, st: S, cb: Callback<S>) {
     for (const el of n.elements) {
       if (el) {
         cb(el.expression, st)
       }
     }
   }
-  ArrayPattern<S>(n: swc.ArrayPattern, st: S, cb: Callback<S>) {
+  ArrayPattern<S>(n: NodeByType<'ArrayPattern'>, st: S, cb: Callback<S>) {
     for (const el of n.elements) {
       if (el) {
         cb(el, st)
       }
     }
   }
-  ArrowFunctionExpression<S>(n: swc.ArrowFunctionExpression, st: S, cb: Callback<S>) {
+  ArrowFunctionExpression<S>(n: NodeByType<'ArrowFunctionExpression'>, st: S, cb: Callback<S>) {
+    for (const param of n.params) {
+      cb(param, st)
+    }
+
     cb(n.body, st)
+
+    if (n.returnType) {
+      cb(n.returnType, st)
+    }
 
     if (n.typeParameters) {
       cb(n.typeParameters, st)
     }
   }
-  AssignmentExpression<S>(n: swc.AssignmentExpression, st: S, cb: Callback<S>) {
+  AssignmentExpression<S>(n: NodeByType<'AssignmentExpression'>, st: S, cb: Callback<S>) {
     cb(n.left, st)
     cb(n.right, st)
   }
-  AssignmentPattern<S>(n: swc.AssignmentPattern, st: S, cb: Callback<S>) {
+  AssignmentPattern<S>(n: NodeByType<'AssignmentPattern'>, st: S, cb: Callback<S>) {
     cb(n.left, st)
     cb(n.right, st)
 
@@ -41,36 +47,37 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(n.typeAnnotation, st)
     }
   }
-  AssignmentPatternProperty<S>(n: swc.AssignmentPatternProperty, st: S, cb: Callback<S>) {
+  AssignmentPatternProperty<S>(n: NodeByType<'AssignmentPatternProperty'>, st: S, cb: Callback<S>) {
     cb(n.key, st)
 
     if (n.value) {
       cb(n.value, st)
     }
   }
-  AssignmentProperty<S>(n: swc.AssignmentProperty, st: S, cb: Callback<S>) {
+  AssignmentProperty<S>(n: NodeByType<'AssignmentProperty'>, st: S, cb: Callback<S>) {
+    cb(n.key, st)
     cb(n.value, st)
   }
-  AwaitExpression<S>(n: swc.AwaitExpression, st: S, cb: Callback<S>) {
+  AwaitExpression<S>(n: NodeByType<'AwaitExpression'>, st: S, cb: Callback<S>) {
     cb(n.argument, st)
   }
   BigIntLiteral = ignore
-  BinaryExpression<S>(n: swc.BinaryExpression, st: S, cb: Callback<S>) {
+  BinaryExpression<S>(n: NodeByType<'BinaryExpression'>, st: S, cb: Callback<S>) {
     cb(n.left, st)
     cb(n.right, st)
   }
-  BlockStatement<S>(n: swc.BlockStatement, st: S, cb: Callback<S>) {
+  BlockStatement<S>(n: NodeByType<'BlockStatement'>, st: S, cb: Callback<S>) {
     for (const stmt of n.stmts) {
       cb(stmt, st)
     }
   }
   BooleanLiteral = ignore
-  BreakStatement<S>(n: swc.BreakStatement, st: S, cb: Callback<S>) {
+  BreakStatement<S>(n: NodeByType<'BreakStatement'>, st: S, cb: Callback<S>) {
     if (n.label) {
       cb(n.label, st)
     }
   }
-  CallExpression<S>(n: swc.CallExpression, st: S, cb: Callback<S>) {
+  CallExpression<S>(n: NodeByType<'CallExpression'>, st: S, cb: Callback<S>) {
     cb(n.callee, st)
 
     for (const arg of n.arguments) {
@@ -81,14 +88,14 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(n.typeArguments, st)
     }
   }
-  CatchClause<S>(n: swc.CatchClause, st: S, cb: Callback<S>) {
+  CatchClause<S>(n: NodeByType<'CatchClause'>, st: S, cb: Callback<S>) {
     if (n.param) {
       cb(n.param, st)
     }
 
     cb(n.body, st)
   }
-  ClassDeclaration<S>(n: swc.ClassDeclaration, st: S, cb: Callback<S>) {
+  ClassDeclaration<S>(n: NodeByType<'ClassDeclaration'>, st: S, cb: Callback<S>) {
     for (const decorator of n.decorators ?? []) {
       cb(decorator, st)
     }
@@ -115,7 +122,7 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(member, st)
     }
   }
-  ClassExpression<S>(n: swc.ClassExpression, st: S, cb: Callback<S>) {
+  ClassExpression<S>(n: NodeByType<'ClassExpression'>, st: S, cb: Callback<S>) {
     for (const decorator of n.decorators ?? []) {
       cb(decorator, st)
     }
@@ -144,7 +151,7 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(member, st)
     }
   }
-  ClassMethod<S>(n: swc.ClassMethod, st: S, cb: Callback<S>) {
+  ClassMethod<S>(n: NodeByType<'ClassMethod'>, st: S, cb: Callback<S>) {
     cb(n.key, st)
 
     for (const decorator of n.function.decorators ?? []) {
@@ -167,7 +174,7 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(n.function.body, st)
     }
   }
-  ClassProperty<S>(n: swc.ClassProperty, st: S, cb: Callback<S>) {
+  ClassProperty<S>(n: NodeByType<'ClassProperty'>, st: S, cb: Callback<S>) {
     for (const decorator of n.decorators ?? []) {
       cb(decorator, st)
     }
@@ -182,15 +189,15 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(n.value, st)
     }
   }
-  Computed<S>(n: swc.ComputedPropName, st: S, cb: Callback<S>) {
+  Computed<S>(n: NodeByType<'Computed'>, st: S, cb: Callback<S>) {
     cb(n.expression, st)
   }
-  ConditionalExpression<S>(n: swc.ConditionalExpression, st: S, cb: Callback<S>) {
+  ConditionalExpression<S>(n: NodeByType<'ConditionalExpression'>, st: S, cb: Callback<S>) {
     cb(n.test, st)
     cb(n.consequent, st)
     cb(n.alternate, st)
   }
-  Constructor<S>(n: swc.Constructor, st: S, cb: Callback<S>) {
+  Constructor<S>(n: NodeByType<'Constructor'>, st: S, cb: Callback<S>) {
     cb(n.key, st)
 
     for (const param of n.params) {
@@ -201,21 +208,21 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(n.body, st)
     }
   }
-  ContinueStatement<S>(n: swc.ContinueStatement, st: S, cb: Callback<S>) {
+  ContinueStatement<S>(n: NodeByType<'ContinueStatement'>, st: S, cb: Callback<S>) {
     if (n.label) {
       cb(n.label, st)
     }
   }
   DebuggerStatement = ignore
-  Decorator<S>(n: swc.Decorator, st: S, cb: Callback<S>) {
+  Decorator<S>(n: NodeByType<'Decorator'>, st: S, cb: Callback<S>) {
     cb(n.expression, st)
   }
-  DoWhileStatement<S>(n: swc.DoWhileStatement, st: S, cb: Callback<S>) {
+  DoWhileStatement<S>(n: NodeByType<'DoWhileStatement'>, st: S, cb: Callback<S>) {
     cb(n.body, st)
     cb(n.test, st)
   }
   EmptyStatement = ignore
-  ExportAllDeclaration<S>(n: swc.ExportAllDeclaration, st: S, cb: Callback<S>) {
+  ExportAllDeclaration<S>(n: NodeByType<'ExportAllDeclaration'>, st: S, cb: Callback<S>) {
     cb(n.source, st)
 
     // @ts-expect-error -- asserts is not typed in ExportAllDeclaration
@@ -226,19 +233,19 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(n.asserts, st)
     }
   }
-  ExportDeclaration<S>(n: swc.ExportDeclaration, st: S, cb: Callback<S>) {
+  ExportDeclaration<S>(n: NodeByType<'ExportDeclaration'>, st: S, cb: Callback<S>) {
     cb(n.declaration, st)
   }
-  ExportDefaultDeclaration<S>(n: swc.ExportDefaultDeclaration, st: S, cb: Callback<S>) {
+  ExportDefaultDeclaration<S>(n: NodeByType<'ExportDefaultDeclaration'>, st: S, cb: Callback<S>) {
     cb(n.decl, st)
   }
-  ExportDefaultExpression<S>(n: swc.ExportDefaultExpression, st: S, cb: Callback<S>) {
+  ExportDefaultExpression<S>(n: NodeByType<'ExportDefaultExpression'>, st: S, cb: Callback<S>) {
     cb(n.expression, st)
   }
-  ExportDefaultSpecifier<S>(n: swc.ExportDefaultSpecifier, st: S, cb: Callback<S>) {
+  ExportDefaultSpecifier<S>(n: NodeByType<'ExportDefaultSpecifier'>, st: S, cb: Callback<S>) {
     cb(n.exported, st)
   }
-  ExportNamedDeclaration<S>(n: swc.ExportNamedDeclaration, st: S, cb: Callback<S>) {
+  ExportNamedDeclaration<S>(n: NodeByType<'ExportNamedDeclaration'>, st: S, cb: Callback<S>) {
     for (const specifier of n.specifiers) {
       cb(specifier, st)
     }
@@ -255,30 +262,30 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(n.asserts, st)
     }
   }
-  ExportNamespaceSpecifier<S>(n: swc.ExportNamespaceSpecifier, st: S, cb: Callback<S>) {
+  ExportNamespaceSpecifier<S>(n: NodeByType<'ExportNamespaceSpecifier'>, st: S, cb: Callback<S>) {
     cb(n.name, st)
   }
-  ExportSpecifier<S>(n: swc.NamedExportSpecifier, st: S, cb: Callback<S>) {
+  ExportSpecifier<S>(n: NodeByType<'ExportSpecifier'>, st: S, cb: Callback<S>) {
     if (n.exported) {
       cb(n.exported, st)
     }
 
     cb(n.orig, st)
   }
-  ExpressionStatement<S>(n: swc.ExpressionStatement, st: S, cb: Callback<S>) {
+  ExpressionStatement<S>(n: NodeByType<'ExpressionStatement'>, st: S, cb: Callback<S>) {
     cb(n.expression, st)
   }
-  ForInStatement<S>(n: swc.ForInStatement, st: S, cb: Callback<S>) {
+  ForInStatement<S>(n: NodeByType<'ForInStatement'>, st: S, cb: Callback<S>) {
     cb(n.left, st)
     cb(n.right, st)
     cb(n.body, st)
   }
-  ForOfStatement<S>(n: swc.ForOfStatement, st: S, cb: Callback<S>) {
+  ForOfStatement<S>(n: NodeByType<'ForOfStatement'>, st: S, cb: Callback<S>) {
     cb(n.left, st)
     cb(n.right, st)
     cb(n.body, st)
   }
-  ForStatement<S>(n: swc.ForStatement, st: S, cb: Callback<S>) {
+  ForStatement<S>(n: NodeByType<'ForStatement'>, st: S, cb: Callback<S>) {
     if (n.init) {
       cb(n.init, st)
     }
@@ -293,7 +300,7 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
 
     cb(n.body, st)
   }
-  FunctionDeclaration<S>(n: swc.FunctionDeclaration, st: S, cb: Callback<S>) {
+  FunctionDeclaration<S>(n: NodeByType<'FunctionDeclaration'>, st: S, cb: Callback<S>) {
     for (const decorator of n.decorators ?? []) {
       cb(decorator, st)
     }
@@ -316,7 +323,7 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(n.body, st)
     }
   }
-  FunctionExpression<S>(n: swc.FunctionExpression, st: S, cb: Callback<S>) {
+  FunctionExpression<S>(n: NodeByType<'FunctionExpression'>, st: S, cb: Callback<S>) {
     for (const decorator of n.decorators ?? []) {
       cb(decorator, st)
     }
@@ -341,7 +348,7 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(n.body, st)
     }
   }
-  GetterProperty<S>(n: swc.GetterProperty, st: S, cb: Callback<S>) {
+  GetterProperty<S>(n: NodeByType<'GetterProperty'>, st: S, cb: Callback<S>) {
     cb(n.key, st)
 
     if (n.typeAnnotation) {
@@ -352,12 +359,12 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(n.body, st)
     }
   }
-  Identifier<S>(n: swc.Identifier | swc.BindingIdentifier, st: S, cb: Callback<S>) {
+  Identifier<S>(n: NodeByType<'Identifier'>, st: S, cb: Callback<S>) {
     if ('typeAnnotation' in n && n.typeAnnotation) {
       cb(n.typeAnnotation, st)
     }
   }
-  IfStatement<S>(n: swc.IfStatement, st: S, cb: Callback<S>) {
+  IfStatement<S>(n: NodeByType<'IfStatement'>, st: S, cb: Callback<S>) {
     cb(n.test, st)
     cb(n.consequent, st)
 
@@ -366,7 +373,7 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
     }
   }
   Import = ignore
-  ImportDeclaration<S>(n: swc.ImportDeclaration, st: S, cb: Callback<S>) {
+  ImportDeclaration<S>(n: NodeByType<'ImportDeclaration'>, st: S, cb: Callback<S>) {
     for (const specifier of n.specifiers) {
       cb(specifier, st)
     }
@@ -381,13 +388,13 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(n.asserts, st)
     }
   }
-  ImportDefaultSpecifier<S>(n: swc.ImportDefaultSpecifier, st: S, cb: Callback<S>) {
+  ImportDefaultSpecifier<S>(n: NodeByType<'ImportDefaultSpecifier'>, st: S, cb: Callback<S>) {
     cb(n.local, st)
   }
-  ImportNamespaceSpecifier<S>(n: swc.ImportNamespaceSpecifier, st: S, cb: Callback<S>) {
+  ImportNamespaceSpecifier<S>(n: NodeByType<'ImportNamespaceSpecifier'>, st: S, cb: Callback<S>) {
     cb(n.local, st)
   }
-  ImportSpecifier<S>(n: swc.NamedImportSpecifier, st: S, cb: Callback<S>) {
+  ImportSpecifier<S>(n: NodeByType<'ImportSpecifier'>, st: S, cb: Callback<S>) {
     if (n.imported) {
       cb(n.imported, st)
     }
@@ -395,18 +402,18 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
     cb(n.local, st)
   }
   Invalid = ignore
-  JSXAttribute<S>(n: swc.JSXAttribute, st: S, cb: Callback<S>) {
+  JSXAttribute<S>(n: NodeByType<'JSXAttribute'>, st: S, cb: Callback<S>) {
     cb(n.name, st)
 
     if (n.value) {
       cb(n.value, st)
     }
   }
-  JSXClosingElement<S>(n: swc.JSXClosingElement, st: S, cb: Callback<S>) {
+  JSXClosingElement<S>(n: NodeByType<'JSXClosingElement'>, st: S, cb: Callback<S>) {
     cb(n.name, st)
   }
   JSXClosingFragment = ignore
-  JSXElement<S>(n: swc.JSXElement, st: S, cb: Callback<S>) {
+  JSXElement<S>(n: NodeByType<'JSXElement'>, st: S, cb: Callback<S>) {
     cb(n.opening, st)
 
     for (const child of n.children) {
@@ -418,10 +425,10 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
     }
   }
   JSXEmptyExpression = ignore
-  JSXExpressionContainer<S>(n: swc.JSXExpressionContainer, st: S, cb: Callback<S>) {
+  JSXExpressionContainer<S>(n: NodeByType<'JSXExpressionContainer'>, st: S, cb: Callback<S>) {
     cb(n.expression, st)
   }
-  JSXFragment<S>(n: swc.JSXFragment, st: S, cb: Callback<S>) {
+  JSXFragment<S>(n: NodeByType<'JSXFragment'>, st: S, cb: Callback<S>) {
     cb(n.opening, st)
 
     for (const child of n.children) {
@@ -430,15 +437,15 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
 
     cb(n.closing, st)
   }
-  JSXMemberExpression<S>(n: swc.JSXMemberExpression, st: S, cb: Callback<S>) {
+  JSXMemberExpression<S>(n: NodeByType<'JSXMemberExpression'>, st: S, cb: Callback<S>) {
     cb(n.property, st)
     cb(n.object, st)
   }
-  JSXNamespacedName<S>(n: swc.JSXNamespacedName, st: S, cb: Callback<S>) {
+  JSXNamespacedName<S>(n: NodeByType<'JSXNamespacedName'>, st: S, cb: Callback<S>) {
     cb(n.namespace, st)
     cb(n.name, st)
   }
-  JSXOpeningElement<S>(n: swc.JSXOpeningElement, st: S, cb: Callback<S>) {
+  JSXOpeningElement<S>(n: NodeByType<'JSXOpeningElement'>, st: S, cb: Callback<S>) {
     cb(n.name, st)
 
     for (const attr of n.attributes) {
@@ -450,28 +457,28 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
     }
   }
   JSXOpeningFragment = ignore
-  JSXSpreadChild<S>(n: swc.JSXSpreadChild, st: S, cb: Callback<S>) {
+  JSXSpreadChild<S>(n: NodeByType<'JSXSpreadChild'>, st: S, cb: Callback<S>) {
     cb(n.expression, st)
   }
   JSXText = ignore
-  KeyValuePatternProperty<S>(n: swc.KeyValuePatternProperty, st: S, cb: Callback<S>) {
+  KeyValuePatternProperty<S>(n: NodeByType<'KeyValuePatternProperty'>, st: S, cb: Callback<S>) {
     cb(n.key, st)
     cb(n.value, st)
   }
-  KeyValueProperty<S>(n: swc.KeyValueProperty, st: S, cb: Callback<S>) {
+  KeyValueProperty<S>(n: NodeByType<'KeyValueProperty'>, st: S, cb: Callback<S>) {
     cb(n.key, st)
     cb(n.value, st)
   }
-  LabeledStatement<S>(n: swc.LabeledStatement, st: S, cb: Callback<S>) {
+  LabeledStatement<S>(n: NodeByType<'LabeledStatement'>, st: S, cb: Callback<S>) {
     cb(n.label, st)
     cb(n.body, st)
   }
-  MemberExpression<S>(n: swc.MemberExpression, st: S, cb: Callback<S>) {
+  MemberExpression<S>(n: NodeByType<'MemberExpression'>, st: S, cb: Callback<S>) {
     cb(n.object, st)
     cb(n.property, st)
   }
   MetaProperty = ignore
-  MethodProperty<S>(n: swc.MethodProperty, st: S, cb: Callback<S>) {
+  MethodProperty<S>(n: NodeByType<'MethodProperty'>, st: S, cb: Callback<S>) {
     for (const decorator of n.decorators ?? []) {
       cb(decorator, st)
     }
@@ -494,12 +501,12 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(n.body, st)
     }
   }
-  Module<S>(n: swc.Module, st: S, cb: Callback<S>) {
+  Module<S>(n: NodeByType<'Module'>, st: S, cb: Callback<S>) {
     for (const stmt of n.body) {
       cb(stmt, st)
     }
   }
-  NewExpression<S>(n: swc.NewExpression, st: S, cb: Callback<S>) {
+  NewExpression<S>(n: NodeByType<'NewExpression'>, st: S, cb: Callback<S>) {
     cb(n.callee, st)
 
     if (n.arguments) {
@@ -514,12 +521,12 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
   }
   NullLiteral = ignore
   NumericLiteral = ignore
-  ObjectExpression<S>(n: swc.ObjectExpression, st: S, cb: Callback<S>) {
+  ObjectExpression<S>(n: NodeByType<'ObjectExpression'>, st: S, cb: Callback<S>) {
     for (const property of n.properties) {
       cb(property, st)
     }
   }
-  ObjectPattern<S>(n: swc.ObjectPattern, st: S, cb: Callback<S>) {
+  ObjectPattern<S>(n: NodeByType<'ObjectPattern'>, st: S, cb: Callback<S>) {
     for (const property of n.properties) {
       cb(property, st)
     }
@@ -528,20 +535,20 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(n.typeAnnotation, st)
     }
   }
-  OptionalChainingExpression<S>(n: swc.OptionalChainingExpression, st: S, cb: Callback<S>) {
+  OptionalChainingExpression<S>(n: NodeByType<'OptionalChainingExpression'>, st: S, cb: Callback<S>) {
     cb(n.base, st)
   }
-  Parameter<S>(n: swc.Param, st: S, cb: Callback<S>) {
+  Parameter<S>(n: NodeByType<'Parameter'>, st: S, cb: Callback<S>) {
     for (const decorator of n.decorators ?? []) {
       cb(decorator, st)
     }
 
     cb(n.pat, st)
   }
-  ParenthesisExpression<S>(n: swc.ParenthesisExpression, st: S, cb: Callback<S>) {
+  ParenthesisExpression<S>(n: NodeByType<'ParenthesisExpression'>, st: S, cb: Callback<S>) {
     cb(n.expression, st)
   }
-  PrivateMethod<S>(n: swc.PrivateMethod, st: S, cb: Callback<S>) {
+  PrivateMethod<S>(n: NodeByType<'PrivateMethod'>, st: S, cb: Callback<S>) {
     cb(n.key, st)
 
     for (const decorator of n.function.decorators ?? []) {
@@ -565,7 +572,7 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
     }
   }
   PrivateName = ignore
-  PrivateProperty<S>(n: swc.PrivateProperty, st: S, cb: Callback<S>) {
+  PrivateProperty<S>(n: NodeByType<'PrivateProperty'>, st: S, cb: Callback<S>) {
     for (const decorator of n.decorators ?? []) {
       cb(decorator, st)
     }
@@ -581,29 +588,29 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
     }
   }
   RegExpLiteral = ignore
-  RestElement<S>(n: swc.RestElement, st: S, cb: Callback<S>) {
+  RestElement<S>(n: NodeByType<'RestElement'>, st: S, cb: Callback<S>) {
     cb(n.argument, st)
 
     if (n.typeAnnotation) {
       cb(n.typeAnnotation, st)
     }
   }
-  ReturnStatement<S>(n: swc.ReturnStatement, st: S, cb: Callback<S>) {
+  ReturnStatement<S>(n: NodeByType<'ReturnStatement'>, st: S, cb: Callback<S>) {
     if (n.argument) {
       cb(n.argument, st)
     }
   }
-  Script<S>(n: swc.Script, st: S, cb: Callback<S>) {
+  Script<S>(n: NodeByType<'Script'>, st: S, cb: Callback<S>) {
     for (const stmt of n.body) {
       cb(stmt, st)
     }
   }
-  SequenceExpression<S>(n: swc.SequenceExpression, st: S, cb: Callback<S>) {
+  SequenceExpression<S>(n: NodeByType<'SequenceExpression'>, st: S, cb: Callback<S>) {
     for (const expression of n.expressions) {
       cb(expression, st)
     }
   }
-  SetterProperty<S>(n: swc.SetterProperty, st: S, cb: Callback<S>) {
+  SetterProperty<S>(n: NodeByType<'SetterProperty'>, st: S, cb: Callback<S>) {
     cb(n.key, st)
     cb(n.param, st)
 
@@ -611,19 +618,19 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(n.body, st)
     }
   }
-  SpreadElement<S>(n: swc.SpreadElement, st: S, cb: Callback<S>) {
+  SpreadElement<S>(n: NodeByType<'SpreadElement'>, st: S, cb: Callback<S>) {
     cb(n.arguments, st)
   }
-  StaticBlock<S>(n: swc.StaticBlock, st: S, cb: Callback<S>) {
+  StaticBlock<S>(n: NodeByType<'StaticBlock'>, st: S, cb: Callback<S>) {
     cb(n.body, st)
   }
   StringLiteral = ignore
   Super = ignore
-  SuperPropExpression<S>(n: swc.SuperPropExpression, st: S, cb: Callback<S>) {
+  SuperPropExpression<S>(n: NodeByType<'SuperPropExpression'>, st: S, cb: Callback<S>) {
     cb(n.obj, st)
     cb(n.property, st)
   }
-  SwitchCase<S>(n: swc.SwitchCase, st: S, cb: Callback<S>) {
+  SwitchCase<S>(n: NodeByType<'SwitchCase'>, st: S, cb: Callback<S>) {
     if (n.test) {
       cb(n.test, st)
     }
@@ -632,14 +639,14 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(consequent, st)
     }
   }
-  SwitchStatement<S>(n: swc.SwitchStatement, st: S, cb: Callback<S>) {
+  SwitchStatement<S>(n: NodeByType<'SwitchStatement'>, st: S, cb: Callback<S>) {
     cb(n.discriminant, st)
 
     for (const cases of n.cases) {
       cb(cases, st)
     }
   }
-  TaggedTemplateExpression<S>(n: swc.TaggedTemplateExpression, st: S, cb: Callback<S>) {
+  TaggedTemplateExpression<S>(n: NodeByType<'TaggedTemplateExpression'>, st: S, cb: Callback<S>) {
     cb(n.tag, st)
     cb(n.template, st)
 
@@ -648,7 +655,7 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
     }
   }
   TemplateElement = ignore
-  TemplateLiteral<S>(n: swc.TemplateLiteral | swc.TsTemplateLiteralType, st: S, cb: Callback<S>) {
+  TemplateLiteral<S>(n: NodeByType<'TemplateLiteral'>, st: S, cb: Callback<S>) {
     for (const quasis of n.quasis) {
       cb(quasis, st)
     }
@@ -666,10 +673,10 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
     }
   }
   ThisExpression = ignore
-  ThrowStatement<S>(n: swc.ThrowStatement, st: S, cb: Callback<S>) {
+  ThrowStatement<S>(n: NodeByType<'ThrowStatement'>, st: S, cb: Callback<S>) {
     cb(n.argument, st)
   }
-  TryStatement<S>(n: swc.TryStatement, st: S, cb: Callback<S>) {
+  TryStatement<S>(n: NodeByType<'TryStatement'>, st: S, cb: Callback<S>) {
     cb(n.block, st)
 
     if (n.handler) {
@@ -680,17 +687,17 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(n.finalizer, st)
     }
   }
-  TsArrayType<S>(n: swc.TsArrayType, st: S, cb: Callback<S>) {
+  TsArrayType<S>(n: NodeByType<'TsArrayType'>, st: S, cb: Callback<S>) {
     cb(n.elemType, st)
   }
-  TsExpressionWithTypeArguments<S>(n: swc.TsExpressionWithTypeArguments, st: S, cb: Callback<S>) {
+  TsExpressionWithTypeArguments<S>(n: NodeByType<'TsExpressionWithTypeArguments'>, st: S, cb: Callback<S>) {
     cb(n.expression, st)
 
     if (n.typeArguments) {
       cb(n.typeArguments, st)
     }
   }
-  TsInterfaceDeclaration<S>(n: swc.TsInterfaceDeclaration, st: S, cb: Callback<S>) {
+  TsInterfaceDeclaration<S>(n: NodeByType<'TsInterfaceDeclaration'>, st: S, cb: Callback<S>) {
     cb(n.id, st)
     cb(n.body, st)
 
@@ -702,24 +709,24 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(n.typeParams, st)
     }
   }
-  TsInterfaceBody<S>(n: swc.TsInterfaceBody, st: S, cb: Callback<S>) {
+  TsInterfaceBody<S>(n: NodeByType<'TsInterfaceBody'>, st: S, cb: Callback<S>) {
     for (const ele of n.body) {
       cb(ele, st)
     }
   }
   TsKeywordType = ignore
-  TsPropertySignature<S>(n: swc.TsPropertySignature, st: S, cb: Callback<S>) {
+  TsPropertySignature<S>(n: NodeByType<'TsPropertySignature'>, st: S, cb: Callback<S>) {
     cb(n.key, st)
 
     if (n.typeAnnotation) {
       cb(n.typeAnnotation, st)
     }
   }
-  TsAsExpression<S>(n: swc.TsAsExpression, st: S, cb: Callback<S>) {
+  TsAsExpression<S>(n: NodeByType<'TsAsExpression'>, st: S, cb: Callback<S>) {
     cb(n.expression, st)
     cb(n.typeAnnotation, st)
   }
-  TsCallSignatureDeclaration<S>(n: swc.TsCallSignatureDeclaration, st: S, cb: Callback<S>) {
+  TsCallSignatureDeclaration<S>(n: NodeByType<'TsCallSignatureDeclaration'>, st: S, cb: Callback<S>) {
     for (const param of n.params) {
       cb(param, st)
     }
@@ -732,16 +739,16 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(n.typeAnnotation, st)
     }
   }
-  TsConditionalType<S>(n: swc.TsConditionalType, st: S, cb: Callback<S>) {
+  TsConditionalType<S>(n: NodeByType<'TsConditionalType'>, st: S, cb: Callback<S>) {
     cb(n.checkType, st)
     cb(n.extendsType, st)
     cb(n.trueType, st)
     cb(n.falseType, st)
   }
-  TsConstAssertion<S>(n: swc.TsConstAssertion, st: S, cb: Callback<S>) {
+  TsConstAssertion<S>(n: NodeByType<'TsConstAssertion'>, st: S, cb: Callback<S>) {
     cb(n.expression, st)
   }
-  TsConstructorType<S>(n: swc.TsConstructorType, st: S, cb: Callback<S>) {
+  TsConstructorType<S>(n: NodeByType<'TsConstructorType'>, st: S, cb: Callback<S>) {
     for (const param of n.params) {
       cb(param, st)
     }
@@ -752,7 +759,7 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(n.typeParams, st)
     }
   }
-  TsConstructSignatureDeclaration<S>(n: swc.TsConstructSignatureDeclaration, st: S, cb: Callback<S>) {
+  TsConstructSignatureDeclaration<S>(n: NodeByType<'TsConstructSignatureDeclaration'>, st: S, cb: Callback<S>) {
     for (const param of n.params) {
       cb(param, st)
     }
@@ -765,27 +772,27 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(n.typeAnnotation, st)
     }
   }
-  TsEnumDeclaration<S>(n: swc.TsEnumDeclaration, st: S, cb: Callback<S>) {
+  TsEnumDeclaration<S>(n: NodeByType<'TsEnumDeclaration'>, st: S, cb: Callback<S>) {
     cb(n.id, st)
 
     for (const member of n.members) {
       cb(member, st)
     }
   }
-  TsEnumMember<S>(n: swc.TsEnumMember, st: S, cb: Callback<S>) {
+  TsEnumMember<S>(n: NodeByType<'TsEnumMember'>, st: S, cb: Callback<S>) {
     cb(n.id, st)
 
     if (n.init) {
       cb(n.init, st)
     }
   }
-  TsExportAssignment<S>(n: swc.TsExportAssignment, st: S, cb: Callback<S>) {
+  TsExportAssignment<S>(n: NodeByType<'TsExportAssignment'>, st: S, cb: Callback<S>) {
     cb(n.expression, st)
   }
-  TsExternalModuleReference<S>(n: swc.TsExternalModuleReference, st: S, cb: Callback<S>) {
+  TsExternalModuleReference<S>(n: NodeByType<'TsExternalModuleReference'>, st: S, cb: Callback<S>) {
     cb(n.expression, st)
   }
-  TsFunctionType<S>(n: swc.TsFunctionType, st: S, cb: Callback<S>) {
+  TsFunctionType<S>(n: NodeByType<'TsFunctionType'>, st: S, cb: Callback<S>) {
     for (const param of n.params) {
       cb(param, st)
     }
@@ -796,18 +803,18 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(n.typeParams, st)
     }
   }
-  TsGetterSignature<S>(n: swc.TsGetterSignature, st: S, cb: Callback<S>) {
+  TsGetterSignature<S>(n: NodeByType<'TsGetterSignature'>, st: S, cb: Callback<S>) {
     cb(n.key, st)
 
     if (n.typeAnnotation) {
       cb(n.typeAnnotation, st)
     }
   }
-  TsImportEqualsDeclaration<S>(n: swc.TsImportEqualsDeclaration, st: S, cb: Callback<S>) {
+  TsImportEqualsDeclaration<S>(n: NodeByType<'TsImportEqualsDeclaration'>, st: S, cb: Callback<S>) {
     cb(n.id, st)
     cb(n.moduleRef, st)
   }
-  TsImportType<S>(n: swc.TsImportType, st: S, cb: Callback<S>) {
+  TsImportType<S>(n: NodeByType<'TsImportType'>, st: S, cb: Callback<S>) {
     cb(n.argument, st)
 
     if (n.qualifier) {
@@ -818,11 +825,11 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(n.typeArguments, st)
     }
   }
-  TsIndexedAccessType<S>(n: swc.TsIndexedAccessType, st: S, cb: Callback<S>) {
+  TsIndexedAccessType<S>(n: NodeByType<'TsIndexedAccessType'>, st: S, cb: Callback<S>) {
     cb(n.indexType, st)
     cb(n.objectType, st)
   }
-  TsIndexSignature<S>(n: swc.TsIndexSignature, st: S, cb: Callback<S>) {
+  TsIndexSignature<S>(n: NodeByType<'TsIndexSignature'>, st: S, cb: Callback<S>) {
     for (const param of n.params) {
       cb(param, st)
     }
@@ -831,22 +838,22 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(n.typeAnnotation, st)
     }
   }
-  TsInferType<S>(n: swc.TsInferType, st: S, cb: Callback<S>) {
+  TsInferType<S>(n: NodeByType<'TsInferType'>, st: S, cb: Callback<S>) {
     cb(n.typeParam, st)
   }
-  TsInstantiation<S>(n: swc.TsInstantiation, st: S, cb: Callback<S>) {
+  TsInstantiation<S>(n: NodeByType<'TsInstantiation'>, st: S, cb: Callback<S>) {
     cb(n.expression, st)
     cb(n.typeArguments, st)
   }
-  TsIntersectionType<S>(n: swc.TsIntersectionType, st: S, cb: Callback<S>) {
+  TsIntersectionType<S>(n: NodeByType<'TsIntersectionType'>, st: S, cb: Callback<S>) {
     for (const type of n.types) {
       cb(type, st)
     }
   }
-  TsLiteralType<S>(n: swc.TsLiteralType, st: S, cb: Callback<S>) {
+  TsLiteralType<S>(n: NodeByType<'TsLiteralType'>, st: S, cb: Callback<S>) {
     cb(n.literal, st)
   }
-  TsMappedType<S>(n: swc.TsMappedType, st: S, cb: Callback<S>) {
+  TsMappedType<S>(n: NodeByType<'TsMappedType'>, st: S, cb: Callback<S>) {
     if (n.nameType) {
       cb(n.nameType, st)
     }
@@ -857,7 +864,7 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
 
     cb(n.typeParam, st)
   }
-  TsMethodSignature<S>(n: swc.TsMethodSignature, st: S, cb: Callback<S>) {
+  TsMethodSignature<S>(n: NodeByType<'TsMethodSignature'>, st: S, cb: Callback<S>) {
     for (const param of n.params) {
       cb(param, st)
     }
@@ -872,70 +879,70 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(n.typeParams, st)
     }
   }
-  TsModuleBlock<S>(n: swc.TsModuleBlock, st: S, cb: Callback<S>) {
+  TsModuleBlock<S>(n: NodeByType<'TsModuleBlock'>, st: S, cb: Callback<S>) {
     for (const stmt of n.body) {
       cb(stmt, st)
     }
   }
-  TsModuleDeclaration<S>(n: swc.TsModuleDeclaration, st: S, cb: Callback<S>) {
+  TsModuleDeclaration<S>(n: NodeByType<'TsModuleDeclaration'>, st: S, cb: Callback<S>) {
     cb(n.id, st)
 
     if (n.body) {
       cb(n.body, st)
     }
   }
-  TsNamespaceDeclaration<S>(n: swc.TsNamespaceDeclaration, st: S, cb: Callback<S>) {
+  TsNamespaceDeclaration<S>(n: NodeByType<'TsNamespaceDeclaration'>, st: S, cb: Callback<S>) {
     cb(n.id, st)
     cb(n.body, st)
   }
-  TsNamespaceExportDeclaration<S>(n: swc.TsNamespaceExportDeclaration, st: S, cb: Callback<S>) {
+  TsNamespaceExportDeclaration<S>(n: NodeByType<'TsNamespaceExportDeclaration'>, st: S, cb: Callback<S>) {
     cb(n.id, st)
   }
-  TsNonNullExpression<S>(n: swc.TsNonNullExpression, st: S, cb: Callback<S>) {
+  TsNonNullExpression<S>(n: NodeByType<'TsNonNullExpression'>, st: S, cb: Callback<S>) {
     cb(n.expression, st)
   }
-  TsOptionalType<S>(n: swc.TsOptionalType, st: S, cb: Callback<S>) {
+  TsOptionalType<S>(n: NodeByType<'TsOptionalType'>, st: S, cb: Callback<S>) {
     cb(n.typeAnnotation, st)
   }
-  TsParameterProperty<S>(n: swc.TsParameterProperty, st: S, cb: Callback<S>) {
+  TsParameterProperty<S>(n: NodeByType<'TsParameterProperty'>, st: S, cb: Callback<S>) {
     for (const decorator of n.decorators ?? []) {
       cb(decorator, st)
     }
 
     cb(n.param, st)
   }
-  TsParenthesizedType<S>(n: swc.TsParenthesizedType, st: S, cb: Callback<S>) {
+  TsParenthesizedType<S>(n: NodeByType<'TsParenthesizedType'>, st: S, cb: Callback<S>) {
     cb(n.typeAnnotation, st)
   }
-  TsQualifiedName<S>(n: swc.TsQualifiedName, st: S, cb: Callback<S>) {
+  TsQualifiedName<S>(n: NodeByType<'TsQualifiedName'>, st: S, cb: Callback<S>) {
     cb(n.left, st)
     cb(n.right, st)
   }
-  TsRestType<S>(n: swc.TsRestType, st: S, cb: Callback<S>) {
+  TsRestType<S>(n: NodeByType<'TsRestType'>, st: S, cb: Callback<S>) {
     cb(n.typeAnnotation, st)
   }
-  TsSatisfiesExpression<S>(n: swc.TsSatisfiesExpression, st: S, cb: Callback<S>) {
+  TsSatisfiesExpression<S>(n: NodeByType<'TsSatisfiesExpression'>, st: S, cb: Callback<S>) {
     cb(n.expression, st)
     cb(n.typeAnnotation, st)
   }
-  TsSetterSignature<S>(n: swc.TsSetterSignature, st: S, cb: Callback<S>) {
+  TsSetterSignature<S>(n: NodeByType<'TsSetterSignature'>, st: S, cb: Callback<S>) {
     cb(n.key, st)
     cb(n.param, st)
   }
   TsThisType = ignore
-  TsTupleElement<S>(n: swc.TsTupleElement, st: S, cb: Callback<S>) {
+  TsTupleElement<S>(n: NodeByType<'TsTupleElement'>, st: S, cb: Callback<S>) {
     if (n.label) {
       cb(n.label, st)
     }
 
     cb(n.ty, st)
   }
-  TsTupleType<S>(n: swc.TsTupleType, st: S, cb: Callback<S>) {
+  TsTupleType<S>(n: NodeByType<'TsTupleType'>, st: S, cb: Callback<S>) {
     for (const el of n.elemTypes) {
       cb(el, st)
     }
   }
-  TsTypeAliasDeclaration<S>(n: swc.TsTypeAliasDeclaration, st: S, cb: Callback<S>) {
+  TsTypeAliasDeclaration<S>(n: NodeByType<'TsTypeAliasDeclaration'>, st: S, cb: Callback<S>) {
     cb(n.id, st)
     cb(n.typeAnnotation, st)
 
@@ -944,10 +951,10 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
     }
   }
   TsType = ignore
-  TsTypeAnnotation<S>(n: swc.TsTypeAnnotation, st: S, cb: Callback<S>) {
+  TsTypeAnnotation<S>(n: NodeByType<'TsTypeAnnotation'>, st: S, cb: Callback<S>) {
     cb(n.typeAnnotation, st)
   }
-  TsTypeParameter<S>(n: swc.TsTypeParameter, st: S, cb: Callback<S>) {
+  TsTypeParameter<S>(n: NodeByType<'TsTypeParameter'>, st: S, cb: Callback<S>) {
     cb(n.name, st)
 
     if (n.constraint) {
@@ -958,82 +965,82 @@ export class BaseVisitor implements Required<RecursiveVisitors<unknown>> {
       cb(n.default, st)
     }
   }
-  TsTypeParameterDeclaration<S>(n: swc.TsTypeParameterDeclaration, st: S, cb: Callback<S>) {
+  TsTypeParameterDeclaration<S>(n: NodeByType<'TsTypeParameterDeclaration'>, st: S, cb: Callback<S>) {
     for (const param of n.parameters) {
       cb(param, st)
     }
   }
-  TsTypeAssertion<S>(n: swc.TsTypeAssertion, st: S, cb: Callback<S>) {
+  TsTypeAssertion<S>(n: NodeByType<'TsTypeAssertion'>, st: S, cb: Callback<S>) {
     cb(n.expression, st)
     cb(n.typeAnnotation, st)
   }
   TsTypeElement = ignore
-  TsTypeLiteral<S>(n: swc.TsTypeLiteral, st: S, cb: Callback<S>) {
+  TsTypeLiteral<S>(n: NodeByType<'TsTypeLiteral'>, st: S, cb: Callback<S>) {
     for (const member of n.members) {
       cb(member, st)
     }
   }
-  TsTypeOperator<S>(n: swc.TsTypeOperator, st: S, cb: Callback<S>) {
+  TsTypeOperator<S>(n: NodeByType<'TsTypeOperator'>, st: S, cb: Callback<S>) {
     cb(n.typeAnnotation, st)
   }
-  TsTypeParameterInstantiation<S>(n: swc.TsTypeParameterInstantiation, st: S, cb: Callback<S>) {
+  TsTypeParameterInstantiation<S>(n: NodeByType<'TsTypeParameterInstantiation'>, st: S, cb: Callback<S>) {
     for (const param of n.params) {
       cb(param, st)
     }
   }
-  TsTypeReference<S>(n: swc.TsTypeReference, st: S, cb: Callback<S>) {
+  TsTypeReference<S>(n: NodeByType<'TsTypeReference'>, st: S, cb: Callback<S>) {
     cb(n.typeName, st)
 
     if (n.typeParams) {
       cb(n.typeParams, st)
     }
   }
-  TsTypePredicate<S>(n: swc.TsTypePredicate, st: S, cb: Callback<S>) {
+  TsTypePredicate<S>(n: NodeByType<'TsTypePredicate'>, st: S, cb: Callback<S>) {
     cb(n.paramName, st)
 
     if (n.typeAnnotation) {
       cb(n.typeAnnotation, st)
     }
   }
-  TsTypeQuery<S>(n: swc.TsTypeQuery, st: S, cb: Callback<S>) {
+  TsTypeQuery<S>(n: NodeByType<'TsTypeQuery'>, st: S, cb: Callback<S>) {
     cb(n.exprName, st)
 
     if (n.typeArguments) {
       cb(n.typeArguments, st)
     }
   }
-  TsUnionType<S>(n: swc.TsUnionType, st: S, cb: Callback<S>) {
+  TsUnionType<S>(n: NodeByType<'TsUnionType'>, st: S, cb: Callback<S>) {
     for (const type of n.types) {
       cb(type, st)
     }
   }
-  UnaryExpression<S>(n: swc.UnaryExpression, st: S, cb: Callback<S>) {
+  UnaryExpression<S>(n: NodeByType<'UnaryExpression'>, st: S, cb: Callback<S>) {
     cb(n.argument, st)
   }
-  UpdateExpression<S>(n: swc.UpdateExpression, st: S, cb: Callback<S>) {
+  UpdateExpression<S>(n: NodeByType<'UpdateExpression'>, st: S, cb: Callback<S>) {
     cb(n.argument, st)
   }
-  VariableDeclaration<S>(n: swc.VariableDeclaration, st: S, cb: Callback<S>) {
+  VariableDeclaration<S>(n: NodeByType<'VariableDeclaration'>, st: S, cb: Callback<S>) {
     for (const decl of n.declarations) {
       cb(decl, st)
     }
   }
-  VariableDeclarator<S>(n: swc.VariableDeclarator, st: S, cb: Callback<S>) {
+  VariableDeclarator<S>(n: NodeByType<'VariableDeclarator'>, st: S, cb: Callback<S>) {
     cb(n.id, st)
 
     if (n.init) {
       cb(n.init, st)
     }
   }
-  WhileStatement<S>(n: swc.WhileStatement, st: S, cb: Callback<S>) {
+  WhileStatement<S>(n: NodeByType<'WhileStatement'>, st: S, cb: Callback<S>) {
     cb(n.test, st)
     cb(n.body, st)
   }
-  WithStatement<S>(n: swc.WithStatement, st: S, cb: Callback<S>) {
+  WithStatement<S>(n: NodeByType<'WithStatement'>, st: S, cb: Callback<S>) {
     cb(n.object, st)
     cb(n.body, st)
   }
-  YieldExpression<S>(n: swc.YieldExpression, st: S, cb: Callback<S>) {
+  YieldExpression<S>(n: NodeByType<'YieldExpression'>, st: S, cb: Callback<S>) {
     if (n.argument) {
       cb(n.argument, st)
     }

--- a/src/walk.ts
+++ b/src/walk.ts
@@ -3,7 +3,6 @@ import { simple as acornSimpleWalk, ancestor as acornAncestor } from 'acorn-walk
 
 import { BaseVisitor } from './baseVisitor.js'
 import type { SimpleVisitors, AncestorVisitors } from './types.js'
-
 export function simple<T = unknown>(
   ast: Node,
   visitors: SimpleVisitors<T>,

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "declaration": false,
-    "noEmit": true
-  },
-  "include": ["*.ts"]
-}

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -3,8 +3,8 @@ import assert from 'node:assert'
 
 import { parseSync, type ParseOptions } from '@swc/core'
 
-import { simple } from '../src/walk.js'
-import { BaseVisitor } from '../src/baseVisitor.js'
+import { simple } from '#swc-walk'
+import BaseVisitor from '#swc-walk/baseVisitor'
 
 export type Test = {
   type: keyof BaseVisitor

--- a/test/walk.test.ts
+++ b/test/walk.test.ts
@@ -137,7 +137,10 @@ describe('swc-walk', () => {
 
     assertNodeType(qualifiedName, 'TsQualifiedName')
 
-    Reflect.deleteProperty(qualifiedName, 'span')
+    // Simulate a missing 'span' property to test runtime behavior where span may be undefined.
+    const deleted = Reflect.deleteProperty(qualifiedName, 'span')
+    assert.ok(deleted, "Failed to delete 'span' property; object may be frozen or sealed")
+    assert.strictEqual(qualifiedName.span, undefined, "'span' property should be undefined after deletion")
 
     const spans: Array<Node['span']> = []
 

--- a/test/walk.test.ts
+++ b/test/walk.test.ts
@@ -139,6 +139,7 @@ describe('swc-walk', () => {
 
     // Simulate a missing 'span' property to test runtime behavior where span may be undefined.
     const deleted = Reflect.deleteProperty(qualifiedName, 'span')
+
     assert.ok(deleted, "Failed to delete 'span' property; object may be frozen or sealed")
     assert.strictEqual(qualifiedName.span, undefined, "'span' property should be undefined after deletion")
 

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./"
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
- add ./types export and package imports so assertNodeType/isNodeOfType are public
- ensure OptionalSpan keeps span key present and regression tests cover both defined/undefined cases
- update tests to use canonical specifiers, add throw coverage, and rework configs (tsconfig split, ESLint flat config) so builds ignore tests while lint/type checking still sees them

**BREAKING CHANGE**:
Nodes that normally carry a `span` still expose the `span` property, but it is typed as `Span | undefined`; handle the potential undefined value instead of checking for property existence.