### PR TITLE
chore: bump version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swc-walk",
-  "version": "1.0.1",
+  "version": "2.0.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "swc-walk",
-      "version": "1.0.1",
+      "version": "2.0.0-rc.0",
       "license": "MIT",
       "dependencies": {
         "acorn-walk": "^8.3.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swc-walk",
-  "version": "1.0.1",
+  "version": "2.0.0-rc.0",
   "description": "Walk an AST from SWC and visit each node type.",
   "main": "dist/esm/walk.js",
   "type": "module",


### PR DESCRIPTION
BREAKING CHANGES:
- span-bearing nodes always expose node.span but it may be undefined, so callers must handle that case